### PR TITLE
Add support for `webhook_avatar_url`s

### DIFF
--- a/pluralkit/v2/models.py
+++ b/pluralkit/v2/models.py
@@ -729,6 +729,7 @@ class Member(Model):
     birthday: Optional[Birthday]
     pronouns: Optional[str]
     avatar_url: Optional[str]
+    webhook_avatar_url: Optional[str]
     keep_proxy: bool
     proxy_tags: Optional[ProxyTags]
     system: SystemId


### PR DESCRIPTION
Simple one line change that worked normally and should hopefully work everywhere else.
(I got tired of the library complaining it doesn't exist, and also just in case someone (us) wants to edit webhook avatars in future)